### PR TITLE
Tweak double gaussian

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,12 @@ Release notes
 =============
 
 
+* Merging https://github.com/lucabaldini/hexsample/pull/45
+* Better parameter initialization for the DoubleGaussian model.
+* Issue(s) closed:
+      * https://github.com/lucabaldini/hexsample/issues/44
+
+
 *hexsample (0.8.0) - Thu, 07 Dec 2023 12:24:46 +0100*
 
 * Merging https://github.com/lucabaldini/hexsample/pull/42

--- a/hexsample/analysis.py
+++ b/hexsample/analysis.py
@@ -88,7 +88,7 @@ def create_histogram(input_file : InputFileBase, column_name : str, mc : bool = 
     return Histogram1d(binning, xlabel=column_name).fill(values)
 
 def fit_histogram(hist : Histogram1d, fit_model : FitModelBase = DoubleGaussian,
-    p0 : np.array = np.array([1., 8000., 150., 1., 8900., 150.]),
+    p0 = None,
     show_figure : bool = True) -> np.array:
     """Fit an histogram given as argument.
 
@@ -115,7 +115,7 @@ def fit_histogram(hist : Histogram1d, fit_model : FitModelBase = DoubleGaussian,
     """
     # pylint: disable=invalid-name
     model = fit_model()
-    model.fit_histogram(hist, p0=p0)
+    model.fit_histogram(hist, p0)
     if show_figure is True:
         hist.plot()
         model.plot()

--- a/hexsample/analysis.py
+++ b/hexsample/analysis.py
@@ -88,22 +88,25 @@ def create_histogram(input_file : InputFileBase, column_name : str, mc : bool = 
     return Histogram1d(binning, xlabel=column_name).fill(values)
 
 def fit_histogram(hist : Histogram1d, fit_model : FitModelBase = DoubleGaussian,
-    p0 = None,
-    show_figure : bool = True) -> np.array:
+    p0 = None, show_figure : bool = True) -> np.array:
     """Fit an histogram given as argument.
 
     Arguments
     ---------
     input_file : DigiInputFile
         The input (digi or recon) file.
+
     hist : Histogram1D
         The histogram to be fitted.
+
     fitting_model : FitModelBase
         The FitModelBase instance containing the model used for fitting the histogram.
         Default is DoubleGaussian.
+
     p0 : np.array
         The array containing the initial parameters of the fit. It must have the same
         len() as the number of parameters of the FitModelBase used for the fit.
+
     plot_figure : bool
         Bool that states if the figure containing the histogram and the best fit has
         to be shown.

--- a/hexsample/modeling.py
+++ b/hexsample/modeling.py
@@ -724,6 +724,10 @@ class DoubleGaussian(_DoubleGaussian):
         # Now subtract the fitted main peak from the data and fit what
         # remains to another gaussian.
         y = ydata - model(xdata)
+        # Set to zero all the stuff under the main peak, so that we don't risk
+        # ending up on the fluctuations of the residuals.
+        mask = np.logical_and(xdata > xmin, xdata < xmax)
+        y[mask] = 0.
         logger.debug(f'Single gaussian fit on the secondary peak...')
         model.fit(xdata, y, p0=(y.max(), xdata[np.argmax(y)], sigma))
         self.set_parameter('normalization1', model['normalization'])

--- a/hexsample/modeling.py
+++ b/hexsample/modeling.py
@@ -431,6 +431,8 @@ class FitModelBase:
         # If we are not passing default starting points for the model parameters,
         # try and do something sensible.
         if p0 is None:
+            if verbose:
+                logger.debug(f'Auto-initializing parameters for {self.name()}...')
             self.init_parameters(xdata, ydata)
             p0 = self.status.par_values
             if verbose:
@@ -685,17 +687,45 @@ class DoubleGaussian(_DoubleGaussian):
     def init_parameters(self, xdata : np.ndarray, ydata : np.ndarray) -> None:
         """Overloaded method.
         """
+        # Take all the data and make a first pass to a single-gaussian fit...
         model = Gaussian()
-        model.fit(xdata, ydata, p0=(ydata.max(), xdata[np.argmax(ydata)], 1.))
+        # ... with a normalization and mean that are set to the position and value
+        # of the highest input data point...
+        norm = ydata.max()
+        max_index = np.argmax(ydata)
+        mean = xdata[max_index]
+        # ... and the sigma is initialized moving away from the main peak
+        # and gauging the FWHM
+        y = norm
+        i = 1
+        while y > 0.5 * norm:
+            y = 0.5 * (ydata[max_index - i] + ydata[max_index + i])
+            i += 1
+        sigma = abs(xdata[max_index - i] - xdata[max_index + i]) / Gaussian.SIGMA_TO_FWHM
+        p0 = (norm, mean, sigma)
+        logger.debug(f'First single-gaussian fit on all data with p0={p0}...')
+        model.fit(xdata, ydata, p0=p0)
+        # Second pass, where we refine the single gaussian fit to the main peak
+        # starting from the parameters at the previous pass and restricting
+        # ourselves to +/- 2 sigma around the peak.
+        # Note that, since we are not passing the errors to this method, even
+        # at this stage the chisquare makes no sense.
         norm, mean, sigma = model.status.par_values
         xmin = mean - 2. * sigma
         xmax = mean + 2. * sigma
-        model.fit(xdata, ydata, p0=(norm, mean, sigma), xmin=xmin, xmax=xmax)
+        p0 = (norm, mean, sigma)
+        logger.debug(f'Second single-gaussian fit in [{xmin}--{xmax}] with p0={p0}...')
+        model.fit(xdata, ydata, p0=p0, xmin=xmin, xmax=xmax)
+        # Cache the single-gaussian fit parameters at the second step, as they
+        # are the initial parameters for the first gaussian in the model.
         self.set_parameter('normalization0', model['normalization'])
         self.set_parameter('mean0', model['mean'])
         self.set_parameter('sigma0', model['sigma'])
+        # Now subtract the fitted main peak from the data and fit what
+        # remains to another gaussian.
         y = ydata - model(xdata)
-        model.fit(xdata, y, p0=(y.max(), xdata[np.argmax(y)], 1.))
+        logger.debug(f'Single gaussian fit on the secondary peak...')
+        model.fit(xdata, y, p0=(y.max(), xdata[np.argmax(y)], sigma))
         self.set_parameter('normalization1', model['normalization'])
         self.set_parameter('mean1', model['mean'])
         self.set_parameter('sigma1', model['sigma'])

--- a/scripts/analyze_grid.py
+++ b/scripts/analyze_grid.py
@@ -93,11 +93,9 @@ def analyze_grid(thickness : np.array, enc : np.array, **kwargs) -> None:
             #Creating histogram for all events
             energy_hist = create_histogram(recon_file, 'energy', binning = 100)
             fitted_model = fit_histogram(energy_hist, DoubleGaussian, show_figure = True)
-            plt.show()
             #Creating histogram for events with 1px on readout
             energy_hist_1px = create_histogram(recon_file, 'energy', mask = mask, binning = 100)
             fitted_model_1px = fit_histogram(energy_hist_1px, DoubleGaussian, show_figure = True)
-            plt.show()
             #Saving the matrix containing the whole FitStatus for further (optional) use
             params_matrix[thick_idx][e_idx] = fitted_model
             params_matrix_1px[thick_idx][e_idx] = fitted_model_1px

--- a/scripts/analyze_grid.py
+++ b/scripts/analyze_grid.py
@@ -92,10 +92,10 @@ def analyze_grid(thickness : np.array, enc : np.array, **kwargs) -> None:
             mask = cluster_size < 2
             #Creating histogram for all events
             energy_hist = create_histogram(recon_file, 'energy', binning = 100)
-            fitted_model = fit_histogram(energy_hist, DoubleGaussian, show_figure = True)
+            fitted_model = fit_histogram(energy_hist, DoubleGaussian, show_figure = False)
             #Creating histogram for events with 1px on readout
             energy_hist_1px = create_histogram(recon_file, 'energy', mask = mask, binning = 100)
-            fitted_model_1px = fit_histogram(energy_hist_1px, DoubleGaussian, show_figure = True)
+            fitted_model_1px = fit_histogram(energy_hist_1px, DoubleGaussian, show_figure = False)
             #Saving the matrix containing the whole FitStatus for further (optional) use
             params_matrix[thick_idx][e_idx] = fitted_model
             params_matrix_1px[thick_idx][e_idx] = fitted_model_1px

--- a/scripts/analyze_sim.py
+++ b/scripts/analyze_sim.py
@@ -6,7 +6,6 @@
 
 """Event file viewer.
 """
-# pylint: disable=trailing-whitespace
 import numpy as np
 
 from hexsample.app import ArgumentParser
@@ -41,23 +40,22 @@ def analyze_sim(thick : int, noise : int) -> None:
     thr = 2 * noise
     file_path = f'/Users/chiara/hexsampledata/sim_{thick}um_{noise}enc_recon_nn2_thr{thr}.h5'
     recon_file = ReconInputFile(file_path)
-    #Constructing the 1px mask 
+    #Constructing the 1px mask
     cluster_size = recon_file.column('cluster_size')
     mask = cluster_size < 2
     #Creating histograms - for all evts and for only evts with 1px
     energy_hist = create_histogram(recon_file, 'energy', binning = 100)
     energy_hist_1px = create_histogram(recon_file, 'energy', mask = mask, binning = 100)
-    print(f'The number of events is: {energy_hist.content.sum()}')
     plt.figure()
-    fitted_model = fit_histogram(energy_hist, DoubleGaussian, show_figure = False)
+    #fitted_model = fit_histogram(energy_hist, DoubleGaussian, show_figure = False)
     plt.title(fr'Energy histogram for t = {thick} $\mu$m, ENC = {noise} - 1px evts')
     plt.xlabel('Energy [eV]')
-    fitted_model_1px = fit_histogram(energy_hist_1px, DoubleGaussian, show_figure = True)
+    fitted_model_1px = fit_histogram(energy_hist_1px, fit_model=DoubleGaussian, show_figure = True)
     recon_file.close()
 
     plt.show()
 
 if __name__ == '__main__':
-    THICKNESS = 500
-    ENC = 40
+    THICKNESS = 50
+    ENC = 10
     analyze_sim(THICKNESS, ENC, **vars(ANALYZESIM_ARGPARSER.parse_args()))

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -76,8 +76,8 @@ def test_models():
 def test_composite_models():
     """
     """
-    rvs = np.append(rng.generator.normal(10., 1.5, size=100000),
-        rng.generator.normal(15., 0.75, size=25000))
+    rvs = np.append(rng.generator.normal(10000., 1500., size=100000),
+        rng.generator.normal(15000., 750., size=25000))
     model = _test_model(DoubleGaussian(), rvs)
     _test_model(Gaussian() + Gaussian(), rvs, model.status.par_values)
 


### PR DESCRIPTION
After improvement in `modeling.py` of `DoubleGaussian` fit method, analysis grids has been cleaned (being the order of fitted parameters guaranteed to be the standard one: 0 for alpha peak, 1 for beta peak) and rerun successfully. 

Changing static method `init_parameters()` in `DoubleGaussian` permitted to improve fit, that now converges for all cases of the grid of values analyzed in `analyze_grid.py`.

PyLint has been run on all modified scripts. 