### PR TITLE
Continuum spectrum

### DIFF
--- a/hexsample/app.py
+++ b/hexsample/app.py
@@ -188,6 +188,10 @@ class ArgumentParser(argparse.ArgumentParser):
         """Add an option group for the source properties.
         """
         group = self.add_argument_group('source', 'X-ray source properties')
+        types = ['lines', 'continuum']
+        group.add_argument('--spectrumtype', type=str, choices=types, default='lines',
+                           help='type of spectrum, choices are between a discrete\
+                           and a continuum spectrum in the range [7000, 9000] eV.')
         group.add_argument('--srcelement', type=str, default='Cu',
             help='element generating the line forest')
         group.add_argument('--srclevel', type=str, default='K',

--- a/hexsample/bin/hxsim.py
+++ b/hexsample/bin/hxsim.py
@@ -35,7 +35,7 @@ from hexsample.fileio import DigiDescriptionSparse, DigiDescriptionRectangular,\
 from hexsample.hexagon import HexagonalLayout
 from hexsample.mc import PhotonList
 from hexsample.roi import Padding
-from hexsample.source import LineForest, GaussianBeam, Source
+from hexsample.source import ContinuumSpectrum, LineForest, GaussianBeam, Source
 from hexsample.sensor import Material, Sensor
 
 
@@ -58,7 +58,11 @@ def hxsim(**kwargs):
     """
     # pylint: disable=too-many-locals, invalid-name
     rng.initialize(seed=kwargs['seed'])
-    spectrum = LineForest(kwargs['srcelement'], kwargs['srclevel'])
+    spectrum_type = kwargs['spectrumtype']
+    if spectrum_type == 'continuum':
+        spectrum = ContinuumSpectrum()
+    else:
+        spectrum = LineForest(kwargs['srcelement'], kwargs['srclevel'])
     beam = GaussianBeam(kwargs['srcposx'], kwargs['srcposy'], kwargs['srcsigma'])
     source = Source(spectrum, beam)
     material = Material(kwargs['actmedium'], kwargs['fano'])

--- a/hexsample/source.py
+++ b/hexsample/source.py
@@ -205,8 +205,6 @@ class SpectrumBase:
         """
         raise NotImplementedError
 
-
-
 class LineForest(SpectrumBase):
 
     """Class describing a set of X-ray emission lines for a given element and
@@ -269,8 +267,46 @@ class LineForest(SpectrumBase):
         """String formatting.
         """
         return f'{self.line_dict}'
+    
+class ContinuumSpectrum(SpectrumBase):
+    """Class describing a continuum and uniform x-ray energy spectrum between
+    a minimum and a maximum value. By now the continuum spectrum is set in the
+    range [7000, 9000] eV, the possibility to choose it in the sim has to be
+    implemented.
 
+    Arguments
+    ---------
+    min_energy : float
+        Minimum energy of the spectrum
+    max_energy : float
+        Maximum energy of the spectrum
+    """
+    def __init__(self, min_energy: float=7000, max_energy: float=9000) -> None:
+        self.minimum_energy = min_energy
+        self.maximum_energy = max_energy
 
+    def rvs(self, size: int  = 1) -> np.ndarray:
+        """Throw random energies from the line forest.
+
+        Arguments
+        ---------
+        size : int
+            The number of X-ray energies to be generated.
+
+        Returns
+        -------
+        energy : np.ndarray of shape ``size``
+            The photon energies in eV.
+        """
+        # Random generating the energies in [minimum_energy, maximum_energy]
+        return rng.generator.uniform(self.minimum_energy, self.maximum_energy, size)
+    
+    def plot(self) -> None:
+        """Plot the continuum spectrum for 1e4 generated photons.
+        """
+        # pylint: disable=invalid-name
+        plt.hist(self.rvs(10000), density=True, width=0.0001, color='black')
+        setup_gca(xlabel='Energy [eV]', ylabel='pdf', logy=True, grids=True)
 
 class Source:
 

--- a/scripts/analyze_sim.py
+++ b/scripts/analyze_sim.py
@@ -39,8 +39,6 @@ def analyze_sim(thick : int, noise : int) -> None:
     """
     thr = 2 * noise
     file_path = f'/Users/chiara/hexsampledata/hxsim_recon.h5'
-    #file_path = f'/Users/chiara/hexsampledata/sim_HexagonalLayout.ODD_Rum_0enc_srcsigma200um_recon.h5'
-    #file_path = f'/Users/chiara/hexsampledata/sim_{thick}um_{noise}enc_recon_nn2_thr{thr}.h5'
     recon_file = ReconInputFile(file_path)
     #Constructing the 1px mask
     cluster_size = recon_file.column('cluster_size')


### PR DESCRIPTION
Added the possibility to generate a source with a continuum spectrum in [7,9] keV in `source.py` and added the option in `hxsim.py` as `spectrum_type`. If anything specified, the spectrum is the default lineforest. If the continuum spectrum is specified, the source element becomes redundant. 