### PR TITLE
Modified display options

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -31,6 +31,7 @@ Release notes
   needed for every feature of the readout chip.
 * Pull requests merged and issues closed:
 
+  - https://github.com/lucabaldini/hexsample/pull/128
   - https://github.com/lucabaldini/hexsample/pull/127
   - https://github.com/lucabaldini/hexsample/pull/124
   - https://github.com/lucabaldini/hexsample/pull/122

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,8 @@
 Release notes
 =============
 
+* `display` command modified to plot just the events when no calibration files are provided,
+  otherwise the reconstructed and Monte Carlo positions are calculated and plotted.
 * Minor changes to `CalibrateDark` and `CalibrateNoise` signal removal.
 * New `calibview` command to visualize calibration files and compare them with Montecarlo truth.
 * New beam shapes added: `SquareBeam` and `RectangleBeam`.

--- a/src/hexsample/cli.py
+++ b/src/hexsample/cli.py
@@ -494,9 +494,10 @@ class CliArgumentParser(argparse.ArgumentParser):
     def add_display_options(self, parser: argparse.ArgumentParser) -> None:
         """Add an option group for the single-event display properties.
         """
-        CliArgumentParser.add_cal_noise_file(parser, default=None, required=False)
-        CliArgumentParser.add_cal_pedestal_file(parser, default=None, required=False)
-        CliArgumentParser.add_cal_gain_file(parser, default=None, required=False)
+        default = tasks.DisplayDefaults
+        CliArgumentParser.add_cal_noise_file(parser, default=default.noise_matrix)
+        CliArgumentParser.add_cal_pedestal_file(parser, default=default.pedestal_matrix)
+        CliArgumentParser.add_cal_gain_file(parser, default=default.gain_matrix)
 
     def add_calibview_options(self, parser: argparse.ArgumentParser) -> None:
         """Add an option group for the calibration view properties.

--- a/src/hexsample/cli.py
+++ b/src/hexsample/cli.py
@@ -495,9 +495,9 @@ class CliArgumentParser(argparse.ArgumentParser):
     def add_display_options(self, parser: argparse.ArgumentParser) -> None:
         """Add an option group for the single-event display properties.
         """
-        CliArgumentParser.add_cal_noise_file(parser, default=None, required=True)
-        CliArgumentParser.add_cal_pedestal_file(parser, default=None, required=True)
-        CliArgumentParser.add_cal_gain_file(parser, default=None, required=True)
+        CliArgumentParser.add_cal_noise_file(parser, default=None, required=False)
+        CliArgumentParser.add_cal_pedestal_file(parser, default=None, required=False)
+        CliArgumentParser.add_cal_gain_file(parser, default=None, required=False)
 
 
     def run(self) -> None:

--- a/src/hexsample/display.py
+++ b/src/hexsample/display.py
@@ -258,10 +258,6 @@ class EventDisplay(HexagonalGridDisplay):
     
     grid: HexagonalGrid
         The grid to use for the display.
-
-    zero_sup_threshold: int
-    
-
     """
 
     def __init__(self, input_file: DigiInputFileBase, grid: HexagonalGrid, **kwargs):

--- a/src/hexsample/display.py
+++ b/src/hexsample/display.py
@@ -271,8 +271,9 @@ class EventDisplay(HexagonalGridDisplay):
         self.axes.set_aspect("equal")
         initial_event = self._input_file.pick_event(int(self.event_id))
         self.draw_digi_event(initial_event, self.zero_sup_threshold)
-        self.draw_positions(self._input_file.current_mc_event(), initial_event,
-                            self._grid, self.zero_sup_threshold)
+        if isinstance(self._grid, HexagonalReadoutBase): 
+            self.draw_positions(self._input_file.current_mc_event(), initial_event,
+                                self._grid, self.zero_sup_threshold)
         self.axes.autoscale()
         self.axes.axis("off")
         self.prev_button.on_clicked(self.prev)
@@ -303,7 +304,8 @@ class EventDisplay(HexagonalGridDisplay):
         """
         self.axes.clear()
         self.draw_digi_event(event, self.zero_sup_threshold)
-        self.draw_positions(self._input_file.current_mc_event(), event, self._grid,
+        if isinstance(self._grid, HexagonalReadoutBase): 
+           self.draw_positions(self._input_file.current_mc_event(), event, self._grid,
                             self.zero_sup_threshold)
         self.axes.autoscale()
         self.axes.axis("off")

--- a/src/hexsample/display.py
+++ b/src/hexsample/display.py
@@ -29,6 +29,8 @@ from matplotlib.collections import PatchCollection
 from matplotlib.patches import RegularPolygon
 from matplotlib.widgets import Button, TextBox
 
+from hexsample.fileio import DigiInputFileBase
+
 from .clustering import ClusteringNN
 from .digi import DigiEventBase, DigiEventCircular, DigiEventRectangular
 from .hexagon import HexagonalGrid
@@ -205,7 +207,7 @@ class HexagonalGridDisplay:
         self.axes.add_collection(collection)
         return collection
 
-    def draw_digi_event(self, event, zero_sup_threshold) -> HexagonCollection:
+    def draw_digi_event(self, event: DigiEventBase, zero_sup_threshold: int) -> HexagonCollection:
         """Draw a digi event.
 
         This is just dispatching the call to the proper method depending
@@ -244,10 +246,29 @@ class HexagonalGridDisplay:
 
 class EventDisplay(HexagonalGridDisplay):
 
-    def __init__(self, input_file, grid: HexagonalGrid, zero_sup_threshold: int = 0, **kwargs):
-        super().__init__(grid, zero_sup_threshold, **kwargs)
+    """Class to display events from a Digi input file.
+
+    If the keyword argument recon_pars is provided, the display will also show the reconstructed
+    positions and the Monte Carlo truth position (if available) on top of the digi event.
+
+    Arguments
+    ---------
+    input_file: DigiInputFileBase
+        The input file to read the events from.
+    
+    grid: HexagonalGrid
+        The grid to use for the display.
+
+    zero_sup_threshold: int
+    
+
+    """
+
+    def __init__(self, input_file: DigiInputFileBase, grid: HexagonalGrid, **kwargs):
+        """Class constructor."""
+        super().__init__(grid, **kwargs)
         self._input_file = input_file
-        self.event_id = kwargs.get("event_id", 0)
+        self.event_id = 0
         ##Draw the previous and next buttons for event navigation
         axprev = self.figure.add_axes([0.7, 0.05, 0.12, 0.075])
         self.prev_button = Button(axprev, 'Previous')
@@ -271,7 +292,7 @@ class EventDisplay(HexagonalGridDisplay):
         self.axes.set_aspect("equal")
         initial_event = self._input_file.pick_event(int(self.event_id))
         self.draw_digi_event(initial_event, self.zero_sup_threshold)
-        if isinstance(self._grid, HexagonalReadoutBase): 
+        if isinstance(self._grid, HexagonalReadoutBase):
             self.draw_positions(self._input_file.current_mc_event(), initial_event,
                                 self._grid, self.zero_sup_threshold)
         self.axes.autoscale()
@@ -304,9 +325,9 @@ class EventDisplay(HexagonalGridDisplay):
         """
         self.axes.clear()
         self.draw_digi_event(event, self.zero_sup_threshold)
-        if isinstance(self._grid, HexagonalReadoutBase): 
-           self.draw_positions(self._input_file.current_mc_event(), event, self._grid,
-                            self.zero_sup_threshold)
+        if isinstance(self._grid, HexagonalReadoutBase):
+            self.draw_positions(self._input_file.current_mc_event(), event, self._grid,
+                                self.zero_sup_threshold)
         self.axes.autoscale()
         self.axes.axis("off")
         # Show current event ID in the text box after picking the event. This can be improved
@@ -337,5 +358,7 @@ class EventDisplay(HexagonalGridDisplay):
         self._draw(event)
 
     def show(self):
+        """Convenience function to setup the matplotlib canvas for an event display.
+        """
         self.setup_gca()
         plt.show()

--- a/src/hexsample/tasks.py
+++ b/src/hexsample/tasks.py
@@ -772,11 +772,24 @@ def calibrate_gain(
     return output_file_path
 
 
+@dataclass(frozen=True)
+class DisplayDefaults:
+    """Default parameters for the display task.
+
+    This is a small helper dataclass to help ensure consistency between the main task
+    definition in this Python module and the command-line interface.
+    """
+
+    noise_matrix: Optional[CalibrationMatrix] = None
+    pedestal_matrix: Optional[CalibrationMatrix] = None
+    gain_matrix: Optional[CalibrationMatrix] = None
+
+
 def display(
         input_file_path: str,
-        noise_matrix: CalibrationMatrix,
-        pedestal_matrix: CalibrationMatrix,
-        gain_matrix: CalibrationMatrix,
+        noise_matrix: Optional[CalibrationMatrix] = DisplayDefaults.noise_matrix,
+        pedestal_matrix: Optional[CalibrationMatrix] = DisplayDefaults.pedestal_matrix,
+        gain_matrix: Optional[CalibrationMatrix] = DisplayDefaults.gain_matrix,
         ) -> None:
     """Display events from a digi file.
 
@@ -785,29 +798,34 @@ def display(
     file_path : str
         The path to the digi file.
 
-    noise_matrix : CalibrationMatrix
+    noise_matrix : CalibrationMatrix, optional
         The noise calibration matrix to use for the display.
 
-    pedestal_matrix : CalibrationMatrix
+    pedestal_matrix : CalibrationMatrix, optional
         The pedestal calibration matrix to use for the display.
 
-    gain_matrix : CalibrationMatrix
+    gain_matrix : CalibrationMatrix, optional
         The gain calibration matrix to use for the display.
     """
     # Open the input file and extract the header and the readout information.
     input_file, header, readout_mode = open_file(input_file_path)
-    array = np.array([noise_matrix, pedestal_matrix, gain_matrix])
-    if np.any(array == None) and not np.all(array == None):
-        logger.warning("At least one of the matrixes is missing!")
-
-    if np.any(array == None):
-        grid = HexagonalGrid(HexagonalLayout(header["layout"]), header["num_cols"],
-                              header["num_rows"], header["pitch"])
-        _ = EventDisplay(input_file, grid, recon_pars=None)
+    cal_matrices = [noise_matrix, gain_matrix, pedestal_matrix]
+    missing = [matrix for matrix in cal_matrices if matrix is None]
+    # Check if any of the calibration matrices is missing.
+    if 0 < len(missing) < len(cal_matrices):
+        logger.warning(f"{len(missing)} calibration matrices are missing.")
+    # Initialize the correct type of event display based on the input matrices.
+    grid_args = HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"], \
+        header["pitch"]
+    # If any of the calibration matrices is missing, we only show the grid with pixel values.
+    if len(missing) > 0:
+        grid = HexagonalGrid(*grid_args)
+        recon_pars = None
+    # If there are no missing calibration matrices, we can also reconstruct the incident photon
+    # position and show it in the event display.
     else:
-        args = HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"],\
-            header["pitch"], noise_matrix, gain_matrix, pedestal_matrix
-        readout = create_readout(readout_mode, header, *args)
+        readout_args = *grid_args, *cal_matrices
+        grid = create_readout(readout_mode, header, *readout_args)
         recon_defaults = ReconstructionDefaults
         recon_pars = dict(
             eta_2pix_rad_sigma=recon_defaults.eta_2pix_rad_sigma,
@@ -818,7 +836,8 @@ def display(
             eta_3pix_theta_sigma=recon_defaults.eta_3pix_theta_sigma,
             pitch=header["pitch"]
         )
-        _ = EventDisplay(input_file, readout, recon_pars=recon_pars)
+    # Create the event display and show the events.
+    EventDisplay(input_file, grid, recon_pars=recon_pars)
     input_file.close()
 
 

--- a/src/hexsample/tasks.py
+++ b/src/hexsample/tasks.py
@@ -795,7 +795,7 @@ def display(
 
     Arguments
     ---------
-    file_path : str
+    input_file_path : str
         The path to the digi file.
 
     noise_matrix : CalibrationMatrix, optional
@@ -824,7 +824,7 @@ def display(
     # If there are no missing calibration matrices, we can also reconstruct the incident photon
     # position and show it in the event display.
     else:
-        readout_args = *grid_args, *cal_matrices
+        readout_args = (*grid_args, *cal_matrices)
         grid = create_readout(readout_mode, header, *readout_args)
         recon_defaults = ReconstructionDefaults
         recon_pars = dict(

--- a/src/hexsample/tasks.py
+++ b/src/hexsample/tasks.py
@@ -21,8 +21,8 @@
 """
 
 import inspect
-import pathlib
 import os
+import pathlib
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -58,7 +58,7 @@ from .fileio import (
     digi_output_file_class,
     peek_readout_type,
 )
-from .hexagon import HexagonalLayout, HexagonalGrid
+from .hexagon import HexagonalGrid, HexagonalLayout
 from .logging_ import logger
 from .mc import PhotonList
 from .readout import (
@@ -515,13 +515,14 @@ def synthesize_calibration_file(
     # Generate the calibration matrix with the appropriate size and values
     calibration_matrix = CalibrationMatrix(num_cols, num_rows)
     rms = mean * percent_rms / 100
-    logger.info(f"Generating {calibration_type.value} calibration matrix with mean {mean:g} and RMS {rms:g}...")
+    logger.info(f"Generating {calibration_type.value} calibration matrix with mean {mean:g}" 
+                f"and RMS {rms:g}...")
     calibration_matrix.values = rng.generator.normal(mean, scale=rms, size=(num_rows, num_cols))
     # Save the calibration matrix to the output directory
     output_path = pathlib.Path(output_dir) / file_name
     logger.info(f"Saving to {output_path}...")
     calibration_matrix.to_hdf5(output_path, calibration_type, True)
-    logger.info(f"Done!")
+    logger.info("Done!")
     return str(output_path)
 
 
@@ -798,7 +799,8 @@ def display(
         logger.warning("At least one of the matrixes is missing!")
 
     if np.any(array == None):
-        grid = HexagonalGrid(HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"], header["pitch"])
+        grid = HexagonalGrid(HexagonalLayout(header["layout"]), header["num_cols"],
+                              header["num_rows"], header["pitch"])
         _ = EventDisplay(input_file, grid, recon_pars=None)
     else:
         args = HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"],\

--- a/src/hexsample/tasks.py
+++ b/src/hexsample/tasks.py
@@ -58,7 +58,7 @@ from .fileio import (
     digi_output_file_class,
     peek_readout_type,
 )
-from .hexagon import HexagonalLayout
+from .hexagon import HexagonalLayout, HexagonalGrid
 from .logging_ import logger
 from .mc import PhotonList
 from .readout import (
@@ -793,20 +793,28 @@ def display(
     """
     # Open the input file and extract the header and the readout information.
     input_file, header, readout_mode = open_file(input_file_path)
-    args = HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"],\
-        header["pitch"], noise_matrix, gain_matrix, pedestal_matrix
-    readout = create_readout(readout_mode, header, *args)
-    recon_defaults = ReconstructionDefaults
-    recon_pars = dict(
-        eta_2pix_rad_sigma=recon_defaults.eta_2pix_rad_sigma,
-        eta_2pix_rad_pivot=recon_defaults.eta_2pix_rad_pivot,
-        eta_3pix_rad_offset=recon_defaults.eta_3pix_rad_offset,
-        eta_3pix_rad_sigma=recon_defaults.eta_3pix_rad_sigma,
-        eta_3pix_rad_pivot=recon_defaults.eta_3pix_rad_pivot,
-        eta_3pix_theta_sigma=recon_defaults.eta_3pix_theta_sigma,
-        pitch=header["pitch"]
-    )
-    _ = EventDisplay(input_file, readout, recon_pars=recon_pars)
+    array = np.array([noise_matrix, pedestal_matrix, gain_matrix])
+    if np.any(array == None) and not np.all(array == None):
+        logger.warning("At least one of the matrixes is missing!")
+
+    if np.any(array == None):
+        grid = HexagonalGrid(HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"], header["pitch"])
+        _ = EventDisplay(input_file, grid, recon_pars=None)
+    else:
+        args = HexagonalLayout(header["layout"]), header["num_cols"], header["num_rows"],\
+            header["pitch"], noise_matrix, gain_matrix, pedestal_matrix
+        readout = create_readout(readout_mode, header, *args)
+        recon_defaults = ReconstructionDefaults
+        recon_pars = dict(
+            eta_2pix_rad_sigma=recon_defaults.eta_2pix_rad_sigma,
+            eta_2pix_rad_pivot=recon_defaults.eta_2pix_rad_pivot,
+            eta_3pix_rad_offset=recon_defaults.eta_3pix_rad_offset,
+            eta_3pix_rad_sigma=recon_defaults.eta_3pix_rad_sigma,
+            eta_3pix_rad_pivot=recon_defaults.eta_3pix_rad_pivot,
+            eta_3pix_theta_sigma=recon_defaults.eta_3pix_theta_sigma,
+            pitch=header["pitch"]
+        )
+        _ = EventDisplay(input_file, readout, recon_pars=recon_pars)
     input_file.close()
 
 


### PR DESCRIPTION
Based on the "Fix_dark" branch. 
For the event display, the arguments for entering matrixes/values of noise, pedestal and gain are now optional from the command line. If there are no input matrixes, only the event is plotted, without the reconstruction. 